### PR TITLE
Add loading state to event creation button

### DIFF
--- a/components/forms/EventForm.tsx
+++ b/components/forms/EventForm.tsx
@@ -1,5 +1,4 @@
 import { useFormik } from "formik";
-import { useState, useEffect } from "react"; 
 import TextInput from "@/components/UI/Inputs/UWDSC/TextInput";
 import TextArea from "@/components/UI/Inputs/UWDSC/TextArea";
 import InputFeedback from "@/components/UI/Inputs/UWDSC/InputFeedback";
@@ -7,6 +6,7 @@ import ToggleSwitch from "@/components/UI/Inputs/UWDSC/ToggleSwitch";
 import Button from "@/components/UI/Button";
 import { EventFormValues } from "@/types/types";
 
+// Helper function to format datetime for input field
 const formatDateTimeForInput = (dateTimeStr: string) => {
   if (!dateTimeStr) return "";
   const date = new Date(dateTimeStr);
@@ -23,7 +23,8 @@ interface EventFormProps {
   success: boolean;
   error: boolean;
   isEditing?: boolean;
-  onClose?: () => void; 
+  loading?: boolean; // <-- parent provides this
+  onClose?: () => void; // optional; parent may pass if desired
 }
 
 export default function EventForm({
@@ -31,9 +32,10 @@ export default function EventForm({
   success,
   error,
   isEditing = false,
-  onClose, 
+  loading = false,
+  onClose,
 }: EventFormProps) {
-  const [loading, setLoading] = useState(false); 
+  // NOTE: no local loading state here — parent manages it
 
   formik.values.startTime = formatDateTimeForInput(formik.values.startTime);
   formik.values.endTime = formatDateTimeForInput(formik.values.endTime);
@@ -44,26 +46,8 @@ export default function EventForm({
     formik.values.bufferedEndTime,
   );
 
-  useEffect(() => {
-    if (success) {
-      setLoading(false); 
-      const timer = setTimeout(() => {
-        if (onClose) onClose(); 
-      }, 1000); 
-      return () => clearTimeout(timer);
-    }
-  }, [success, onClose]);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setLoading(true);
-    formik.handleSubmit(); 
-
-    setTimeout(() => setLoading(false), 5000);
-  };
-
   return (
-    <form onSubmit={handleSubmit} className="space-y-6">
+    <form onSubmit={formik.handleSubmit} className="space-y-6">
       <div className="mb-6">
         <h2 className="text-2xl font-bold text-white">
           {isEditing ? "Edit Event" : "Add New Event"}
@@ -258,14 +242,11 @@ export default function EventForm({
         font="font-bold"
         text="sm:text-lg 2xl:text-xl"
         rounded="rounded-[15px]"
-        classes="w-full"
-        disabled={loading} 
+        // ✅ Use parent loading state to style/disable the button
+        classes={`w-full ${loading ? "opacity-50 cursor-not-allowed" : ""}`}
+        disabled={loading}
       >
-        {loading
-          ? "Processing..." 
-          : isEditing
-          ? "Update Event"
-          : "Create Event"}
+        {loading ? "Processing..." : isEditing ? "Update Event" : "Create Event"}
       </Button>
 
       {success && (

--- a/pages/events.tsx
+++ b/pages/events.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+// Events.tsx
+import { useState, useEffect, useMemo } from "react";
 import { useFormik } from "formik";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "@/store/store";
@@ -109,7 +110,7 @@ function Events() {
   const [success, setSuccess] = useState<boolean>(false);
   const [error, setError] = useState<boolean>(false);
   const [upcomingEvents, setUpcomingEvents] = useState<FormattedEvent[]>([]);
-  const [loading, setLoading] = useState<boolean>(true);
+  const [loading, setLoading] = useState<boolean>(true); // data fetch loading
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [selectedEvent, setSelectedEvent] = useState<FormattedEvent | null>(
     null,
@@ -119,6 +120,9 @@ function Events() {
   const eventFormOpen = useSelector(
     (state: RootState) => state.eventFormPage.value,
   );
+
+  // NEW: loading state for create/edit API calls (so UI can disable submit)
+  const [submitting, setSubmitting] = useState<boolean>(false); // <-- this is the important one for EventForm
 
   // Fetch events
   useEffect(() => {
@@ -182,13 +186,16 @@ function Events() {
     initialValues: formikInitialValues,
     validationSchema: EventValidationSchema,
     enableReinitialize: true,
-    onSubmit: async (values, { resetForm }) => {
-      try {
-        setSuccess(false);
-        setError(false);
 
-        if (selectedEvent) {
-          // For editing, only send changed fields
+    // IMPORTANT: onSubmit contains the real API calls.
+    onSubmit: async (values, { resetForm }) => {
+      // top-level state for UX
+      setSuccess(false);
+      setError(false);
+
+      // EDIT flow
+      if (selectedEvent) {
+        try {
           const changedFields = getChangedFields(selectedEvent, values);
 
           // If no fields have changed, just close the form
@@ -229,20 +236,36 @@ function Events() {
             );
           }
 
-          const response = await editEvent(selectedEvent.id, changedFields);
-          if (response.data.success) {
-            resetForm();
-            setSuccess(true);
-            dispatch(removeEventForm());
-            // Trigger events refresh
-            setRefreshTrigger((prev) => prev + 1);
-            // Reset success after a delay
-            setTimeout(() => {
-              setSuccess(false);
-            }, 3000);
+          // === Jocelyn's recommended pattern: set loading just before API ===
+          setSubmitting(true); // start loading for API call
+          try {
+            const response = await editEvent(selectedEvent.id, changedFields);
+            if (response.data.success) {
+              resetForm();
+              setSuccess(true);
+              dispatch(removeEventForm());
+              // Trigger events refresh
+              setRefreshTrigger((prev) => prev + 1);
+              // Reset success after a delay
+              setTimeout(() => {
+                setSuccess(false);
+              }, 3000);
+            } else {
+              setError(true);
+            }
+          } catch (err) {
+            console.error("Error editing event:", err);
+            setError(true);
+          } finally {
+            setSubmitting(false); // always stop loading
           }
-        } else {
-          // For creating new events, send all fields
+        } catch (err) {
+          console.error("Unexpected error during edit flow:", err);
+          setError(true);
+        }
+      } else {
+        // CREATE flow
+        try {
           // Create date objects from form values
           const startTimeDate = new Date(values.startTime);
           const endTimeDate = new Date(values.endTime);
@@ -266,21 +289,33 @@ function Events() {
             requirements: values.requirements,
           };
 
-          const response = await createEvent(formattedValues);
-          if (response.data.success) {
-            resetForm();
-            setSuccess(true);
-            dispatch(removeEventForm());
-            // Trigger events refresh
-            setRefreshTrigger((prev) => prev + 1);
-            // Reset success after a delay
-            setTimeout(() => {
-              setSuccess(false);
-            }, 3000);
+          //loading pattern 
+          setSubmitting(true); // start loading
+          try {
+            const response = await createEvent(formattedValues);
+            if (response.data.success) {
+              resetForm();
+              setSuccess(true);
+              dispatch(removeEventForm());
+              // Trigger events refresh
+              setRefreshTrigger((prev) => prev + 1);
+              // Reset success after a delay
+              setTimeout(() => {
+                setSuccess(false);
+              }, 3000);
+            } else {
+              setError(true);
+            }
+          } catch (err) {
+            console.error("Error creating event:", err);
+            setError(true);
+          } finally {
+            setSubmitting(false); // always stop loading
           }
+        } catch (err) {
+          console.error("Unexpected error during create flow:", err);
+          setError(true);
         }
-      } catch (error: any) {
-        setError(true);
       }
     },
   });
@@ -314,7 +349,6 @@ function Events() {
         }
       } catch (error: any) {
         console.error("Error deleting event:", error);
-        // You could add a toast notification here for better UX
       }
     }
   };
@@ -408,6 +442,8 @@ function Events() {
                     success={success}
                     error={error}
                     isEditing={!!selectedEvent}
+                    loading={submitting} // <-- pass submitting state to child
+                    onClose={handleCloseEventForm} // optional
                   />
                 </div>
               </div>,


### PR DESCRIPTION
Pull Request

Closes Issue

closes #158

Changes Made

- Added a loading state to the “Create Event” button on the admin events page.

- Disabled the button while the API call is in progress to prevent multiple submissions.

- Button text updates to “Processing…” while the request is pending.

- Ensures that only one API call can happen at a time.

- Displays an error message if the API call fails, so admins know to try again or contact the dev team.

Testing Steps

- Navigate to the Admin Events page.

- Fill out a new event form and click Create Event.

- Verify that the button changes to “Processing…” and is disabled until the API call resolves.

- Check that after a successful API call, the new event appears in the list.

- Optionally, simulate a failed API call (e.g., disconnect network) and ensure an error message appears and the button is re-enabled.

Additional Notes/Screenshots/Videos (Optional)

The only UI change is the button text and disabled state during submission.
